### PR TITLE
More correct comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+covariations-test
+errors.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+covariations-test: main.cpp
+	g++ -std=c++11 -o $@ $<
+errors.txt: covariations-test
+	./covariations-test > errors.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 covariations-test: main.cpp
 	g++ -std=c++11 -o $@ $<
+
 errors.txt: covariations-test
 	./covariations-test > errors.txt
+
+clean:
+	rm -f covariations-test errors.txt

--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ public:
     std::string Name() const override;
 };
 
-using TDummyCovariationCalculator = TTypedCovariationCalculator<double>;
+using TDummyCovariationCalculator = TTypedCovariationCalculator<long double>;
 using TKahanCovariationCalculator = TTypedCovariationCalculator<TKahanAccumulator>;
 
 template <>


### PR DESCRIPTION
Actually Kahan accumulator uses twice more digits to archieve sum of values.
So the correct way is compare it vs Naive way with double more precision.
In this case Dummy calculator don't loose with mean = 1e5 and loose no so much with mean=1e7